### PR TITLE
材料插件刷取推荐：使用一图流的计算结果

### DIFF
--- a/src/arknights/material/template/material.css
+++ b/src/arknights/material/template/material.css
@@ -152,14 +152,18 @@ body {
 }
 
 .sub_title {
-    margin: 15px 0;
+    margin: 10px 0;
     font-size: 20px;
 }
 
 .description {
     padding: 0;
-    margin: 6px 0;
+    margin: 8px 0;
     color: #aaa;
+}
+
+.mb-extra {
+    margin-bottom: 14px;
 }
 
 .recommend-table {

--- a/src/arknights/material/template/material.css
+++ b/src/arknights/material/template/material.css
@@ -152,8 +152,18 @@ body {
 }
 
 .sub_title {
-    margin-bottom: 20px;;
+    margin: 15px 0;
     font-size: 20px;
+}
+
+.description {
+    padding: 0;
+    margin: 6px 0;
+    color: #aaa;
+}
+
+.recommend-table {
+    padding-bottom: 10px;
 }
 
 .recommend-table td {

--- a/src/arknights/material/template/material.html
+++ b/src/arknights/material/template/material.html
@@ -35,7 +35,7 @@
             </div>
         </template>
         <div class="title" v-if="data.recommend.length">推荐刷取地图</div>
-        <p class="description">排序算法综合考虑刷取效率、副产物价值、掉落体验三项指标，为博士推荐最优关卡。</p>
+        <p class="description mb-extra">排序算法综合考虑刷取效率、副产物价值、掉落体验三项指标，为博士推荐最优关卡。</p>
         <template v-for="material in data.recommend">
             <div class="sub_title">{{material.name}}</div>
             <table class="recommend-table">

--- a/src/arknights/material/template/material.html
+++ b/src/arknights/material/template/material.html
@@ -34,6 +34,29 @@
                 </div>
             </div>
         </template>
+        <div class="title" v-if="data.recommend.length">推荐刷取地图</div>
+        <p class="description">排序算法综合考虑刷取效率、副产物价值、掉落体验三项指标，为博士推荐最优关卡。</p>
+        <template v-for="material in data.recommend">
+            <div class="sub_title">{{material.name}}</div>
+            <table class="recommend-table">
+                <tr>
+                    <td>关卡编号</td>
+                    <td>理智效率</td>
+                    <td>理智期望</td>
+                    <td>掉落概率</td>
+                    <td>置信度</td>
+                </tr>
+                <tr class="recommend-stage" v-for="stage in material.stages">
+                    <td>{{ stage.stageId }}</td>
+                    <td>{{ stage.stageEfficiency }}</td>
+                    <td>{{ stage.apExpect }}</td>
+                    <td>{{ stage.knockRating }}</td>
+                    <td>{{ stage.sampleConfidence }}</td>
+                </tr>
+            </table>
+        </template>
+        <p class="description">数据来源：企鹅物流数据统计（https://penguin-stats.cn）</p>
+        <p class="description">数据计算：明日方舟一图流（https://yituliu.site）</p>
         <template v-if="Object.keys(data.source.main).length || Object.keys(data.source.act).length">
             <div class="title">地图掉落信息</div>
             <div class="source-info">
@@ -63,29 +86,6 @@
                 </div>
             </div>
         </template>
-        <template v-if="data.recommend.length">
-            <div class="title">推荐刷取地图</div>
-            <table class="recommend-table">
-                <tr>
-                    <td>关卡编号</td>
-                    <td>关卡名</td>
-                    <td>所属</td>
-                    <td>理智</td>
-                    <td>单件平均掉率</td>
-                    <td>单件期望理智</td>
-                    <td>备注</td>
-                </tr>
-                <tr class="recommend-stage" v-for="item in data.recommend">
-                    <td>{{ item.code }}</td>
-                    <td>{{ item.name }}</td>
-                    <td>{{ stageType[item.stageType] }}</td>
-                    <td>{{ item.apCost }}</td>
-                    <td>{{ (item.rate * 100).toFixed(2) }}%</td>
-                    <td>{{ parseInt(item.desired) }}</td>
-                    <td>{{ remark(item.stageType) }}</td>
-                </tr>
-            </table>
-        </template>
     </template>
 </div>
 </body>
@@ -110,11 +110,6 @@
         methods: {
             init(data) {
                 this.$set(this, 'data', data)
-            },
-            remark(type) {
-                if (type === 'ACTIVITY') {
-                    return '仅在活动开放或复刻期间有效'
-                }
             }
         },
         data() {


### PR DESCRIPTION
优化材料插件的推荐刷取地图功能。

- 使用[一图流](https://yituliu.site)的计算结果和排序算法，综合考虑主产物的刷取效率（期望理智）、副产物的价值（理智效率）、刷取体验（材料掉率）进行排序；
  - 对于蓝材料和绿材料，直接推荐适合刷取的关卡；
  - 对于紫材料，由于掉率太低，不适合直接刷取，因此分别推荐合成所需材料的对应关卡。
  - 对于其它材料，往往有更好的获得方式，因此不再推荐刷取。
- 修改后，不再需要直接下载企鹅物流的数据，直接使用一图流的计算结果即可，因此移除了企鹅物流的数据。