### PR TITLE
修复材料插件的Bug、优化排版

### DIFF
--- a/src/arknights/material/main.py
+++ b/src/arknights/material/main.py
@@ -119,7 +119,7 @@ class MaterialData:
             return a.knockRating - b.knockRating
 
         def compare_ap_expect(a, b):
-            if a.apExpect < b.apExpect:
+            if a.apExpect <= b.apExpect:
                 r = (b.apExpect - a.apExpect) / b.apExpect
                 if r > 0.03:
                     return 1
@@ -128,7 +128,7 @@ class MaterialData:
                 return -compare_ap_expect(b, a)
 
         def compare_efficiency(a, b):
-            if a.stageEfficiency > b.stageEfficiency:
+            if a.stageEfficiency >= b.stageEfficiency:
                 r = (a.stageEfficiency - b.stageEfficiency) / a.stageEfficiency
                 if r > 0.03:
                     return 1

--- a/src/arknights/material/template/material.css
+++ b/src/arknights/material/template/material.css
@@ -166,8 +166,22 @@ body {
     margin-bottom: 14px;
 }
 
+.table-container {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 6px 40px;
+    padding-left: 40px;
+}
+
+.table-wrapper {
+    width: 46%;
+}
+
 .recommend-table {
     padding-bottom: 10px;
+    width: 100%;
 }
 
 .recommend-table td {

--- a/src/arknights/material/template/material.html
+++ b/src/arknights/material/template/material.html
@@ -36,25 +36,27 @@
         </template>
         <div class="title" v-if="data.recommend.length">推荐刷取地图</div>
         <p class="description mb-extra">排序算法综合考虑刷取效率、副产物价值、掉落体验三项指标，为博士推荐最优关卡。</p>
-        <template v-for="material in data.recommend">
-            <div class="sub_title">{{material.name}}</div>
-            <table class="recommend-table">
-                <tr>
-                    <td>关卡编号</td>
-                    <td>理智效率</td>
-                    <td>理智期望</td>
-                    <td>掉落概率</td>
-                    <td>置信度</td>
-                </tr>
-                <tr class="recommend-stage" v-for="stage in material.stages">
-                    <td>{{ stage.stageId }}</td>
-                    <td>{{ stage.stageEfficiency }}</td>
-                    <td>{{ stage.apExpect }}</td>
-                    <td>{{ stage.knockRating }}</td>
-                    <td>{{ stage.sampleConfidence }}</td>
-                </tr>
-            </table>
-        </template>
+        <div class="table-container">
+            <div v-for="material in data.recommend" class="table-wrapper">
+                <div class="sub_title">{{material.name}}</div>
+                <table class="recommend-table">
+                    <tr>
+                        <td>关卡编号</td>
+                        <td>理智效率</td>
+                        <td>理智期望</td>
+                        <td>掉落概率</td>
+                        <td>置信度</td>
+                    </tr>
+                    <tr class="recommend-stage" v-for="stage in material.stages">
+                        <td>{{ stage.stageId }}</td>
+                        <td>{{ stage.stageEfficiency }}</td>
+                        <td>{{ stage.apExpect }}</td>
+                        <td>{{ stage.knockRating }}</td>
+                        <td>{{ stage.sampleConfidence }}</td>
+                    </tr>
+                </table>
+            </div>
+        </div>
         <p class="description">数据来源：企鹅物流数据统计（https://penguin-stats.cn）</p>
         <p class="description">数据计算：明日方舟一图流（https://yituliu.site）</p>
         <template v-if="Object.keys(data.source.main).length || Object.keys(data.source.act).length">


### PR DESCRIPTION
1. 金材料：之前没有考虑金材料，现在会按照合成表分解到蓝材料为止，推荐所需的蓝材料。
2. 排版：由于金材料合成所需的蓝材料种类较多，因此将推荐表格显示在两列中。
3. Bug修复：修复了两关效率相等时比较函数无限递归的问题。

我不清楚版本号应该如何增加，因此版本号没有变更；代码格式化我也没有找到用的是什么工具（尝试了black.sh，但是不对），这两点麻烦再处理一下。

![image](https://user-images.githubusercontent.com/34163622/231938370-dded9fdf-d927-48a6-9cd0-d3d40c55792e.png)
