### PR TITLE
为所有查询添加名字&公招提示优化

### DIFF
--- a/src/arknights/enemy/main.py
+++ b/src/arknights/enemy/main.py
@@ -122,7 +122,7 @@ async def _(data: Message):
 
 
 @bot.on_message(verify=verify, allow_direct=True)
-async def _(data: Message):
+async def enemy_query(data: Message):
     enemy_name = ''
     for reg in ['敌人(资料)?(.*)', '敌方(资料)?(.*)']:
         r = re.search(re.compile(reg), data.text)

--- a/src/arknights/operatorArchives/main.py
+++ b/src/arknights/operatorArchives/main.py
@@ -21,7 +21,7 @@ class WaitALLRequestsDone(ChainBuilder):
 
 
 @bot.on_message(group_id='operator', keywords=['模组'], level=default_level)
-async def _(data: Message):
+async def operator_archives_module_func(data: Message):
     info = search_info(data, source_keys=['name'])
 
     if not info.name:
@@ -45,7 +45,7 @@ async def _(data: Message):
 
 
 @bot.on_message(group_id='operator', keywords=['语音'], level=default_level)
-async def _(data: Message):
+async def operator_archives_voice_func(data: Message):
     info = search_info(data, source_keys=['voice_key', 'name'])
 
     voice_type = ''
@@ -128,7 +128,7 @@ async def _(data: Message):
 
 
 @bot.on_message(group_id='operator', keywords=['档案', '资料'], level=default_level)
-async def _(data: Message):
+async def operator_archives_story_func(data: Message):
     info = search_info(data, source_keys=['story_key', 'name'])
 
     if not info.name:
@@ -180,7 +180,7 @@ async def _(data: Message):
 
 
 @bot.on_message(group_id='operator', keywords=['皮肤', '立绘'], level=default_level)
-async def _(data: Message):
+async def operator_archives_skin_func(data: Message):
     info = search_info(data, source_keys=['skin_key', 'name'])
 
     skin_item = None
@@ -232,7 +232,7 @@ async def _(data: Message):
 
 
 @bot.on_message(group_id='operator', verify=FuncsVerify.level_up)
-async def _(data: Message):
+async def operator_archives_skill_and_material_func(data: Message):
     info: OperatorSearchInfo = data.verify.keypoint
 
     if not info.name:
@@ -283,7 +283,7 @@ async def operator_func(data: Message, info: Optional[OperatorSearchInfo] = None
 
 
 @bot.on_message(group_id='operator', verify=FuncsVerify.group)
-async def _(data: Message):
+async def operator_archives_group_query_1(data: Message):
     info: OperatorSearchInfo = data.verify.keypoint
 
     if not info.group_key:
@@ -323,7 +323,7 @@ async def _(data: Message):
 
 
 @bot.on_message(group_id='operator', keywords='阵营', level=default_level)
-async def _(data: Message):
+async def operator_archives_group_query_2(data: Message):
     operator_group = OperatorInfo.operator_group_map
 
     text = '|阵营名|干员|\n|----|----|\n'
@@ -336,7 +336,7 @@ async def _(data: Message):
 
 
 @bot.on_message(group_id='operator', keywords=['/干员资料', '/干员查询'])
-async def _(data: Message):
+async def operator_archives_operator_query(data: Message):
     res = await FuncsVerify.operator(data)
     if res[0]:
         return await operator_func(data, res[2])

--- a/src/arknights/recruit/main.py
+++ b/src/arknights/recruit/main.py
@@ -15,6 +15,7 @@ from itertools import combinations
 from amiyabot import event_bus
 from amiyabot.network.download import download_async
 from amiyabot.adapters.cqhttp import CQHttpBotInstance
+from amiyabot.adapters.tencent.qqGroup import QQGroupBotInstance
 
 from core import log, Message, Chain, AmiyaBotPluginInstance, Requirement
 from core.util import all_match, read_yaml, create_dir, run_in_thread_pool
@@ -302,7 +303,10 @@ async def _(data: Message):
             if wait and wait.image:
                 return await Recruit.action(wait, await get_ocr_result(wait), ocr=True)
             else:
-                return Chain(data, at=True).text('博士，您没有发送图片哦~如有需要，请再 at 我并发送“公招”使用该功能~')
+                append_text = ""
+                if type(data.instance) is QQGroupBotInstance:
+                    append_text = "我只能接收到at我的消息，您可能是发送图片时忘记at我了呢。如有需要再 at 我并发送“公招”使用该功能~"
+                return Chain(data, at=True).text(f'博士，您没有发送图片哦~{append_text}')
 
 
 @bot.on_message(verify=auto_discern, check_prefix=False, allow_direct=True)


### PR DESCRIPTION
优化公招提示，强调需要at才能发送截图。

将所有干预查询和敌方查询的handler函数全部命名，用于在未来其他插件直接调用他们，